### PR TITLE
Add a Github Actions workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,10 +21,18 @@ jobs:
             sudo apt install llvm-16 llvm-16-dev llvm-16-tools clang-16 clang-tidy-16 clang-tools-16 libclang-16-dev lld-16
       - name: Build weekly code
         run: |
-          mkdir -p out
           for file in ./week_*/*/*.cpp; do
-            clang++ -std=c++20 -Wall -Wextra -Wpedantic -Wconversion "$file" -o ./out/$(basename "$file" .cpp).o
-          done
+            # Extract the week number and subfolder name from the file path
+            week_folder=$(dirname "$file")
+            week_number=$(basename "$week_folder" | sed 's/week_//')
+            subfolder_name=$(basename "$week_folder")
+
+            # Create the output directory for this week and subfolder if it doesn't exist
+            mkdir -p "./out/week${week_number}_${subfolder_name}"
+
+            # Compile the cpp file and place it in the specified output location
+            clang++ -std=c++20 -Wall -Wextra -Wpedantic -Wconversion "$file" -o "./out/week${week_number}_${subfolder_name}/$(basename "$file" .cpp).o"
+         done
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,17 +22,17 @@ jobs:
       - name: Build weekly code
         run: |
           for file in ./week_*/*/*.cpp; do
-            # Extract the week number and subfolder name from the file path
-            week_folder=$(dirname "$file")
-            week_number=$(basename "$week_folder" | sed 's/week_//')
-            subfolder_name=$(basename "$week_folder")
+              # Extract the week number and subfolder name from the file path
+              week_folder=$(dirname "$file")
+              week_number=$(basename "$week_folder" | sed 's/week_//')
+              subfolder_name=$(basename "$week_folder")
 
-            # Create the output directory for this week and subfolder if it doesn't exist
-            mkdir -p "./out/week${week_number}_${subfolder_name}"
+              # Create the output directory for this week and subfolder if it doesn't exist
+              mkdir -p "./out/week${week_number}_${subfolder_name}"
 
-            # Compile the cpp file and place it in the specified output location
-            clang++ -std=c++20 -Wall -Wextra -Wpedantic -Wconversion "$file" -o "./out/week${week_number}_${subfolder_name}/$(basename "$file" .cpp).o"
-         done
+              # Compile the cpp file and place it in the specified output location
+              clang++ -std=c++20 -Wall -Wextra -Wpedantic -Wconversion "$file" -o "./out/week${week_number}_${subfolder_name}/$(basename "$file" .cpp).o"
+          done
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,33 @@
+name: Build
+
+on: [push]
+jobs:
+  build:
+    name: "Build source code"
+    runs-on: ubuntu-22.04
+    env:
+        CC: clang-16
+        CXX: clang++-16
+        CLANG_DIR: '/usr/lib/llvm-16/lib/cmake/clang'
+        LLVM_DIR: '/usr/lib/llvm-16/lib/cmake/llvm'
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Install a compiler toolchain
+        run: |
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+            sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
+            sudo apt update
+            sudo apt install llvm-16 llvm-16-dev llvm-16-tools clang-16 clang-tidy-16 clang-tools-16 libclang-16-dev lld-16
+      - name: Build weekly code
+        run: |
+          mkdir -p out
+          for file in ./week_*/*/*.cpp; do
+            clang++ -std=c++20 -Wall -Wextra -Wpedantic -Wconversion "$file" -o ./out/$(basename "$file" .cpp).o
+          done
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: out 
+          path: |
+            out


### PR DESCRIPTION
This just builds each `.cpp` file in a subfolder with the clang compiler and then stores the compiled program in a artifact on Github. The last step isn't really necessary here though. I enabled most of the important warnings from the compiler, but did not add -Werror so it shouldn't cause any major compilation errors (just warnings).

I should mention that it builds the code into a single `welcome.o` file for example, and does not place it into a subfolder in the out folder. So if there are two files with the same name, in different weeks, it might cause problems atm. I'm yet to figure out how to improve the github action so that it adds a `week_3_welcome_` prefix.